### PR TITLE
Fixed the blocked texts on the about page

### DIFF
--- a/app/src/main/res/layout-v21/activity_about.xml
+++ b/app/src/main/res/layout-v21/activity_about.xml
@@ -18,6 +18,10 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/about"
         android:layout_width="match_parent"
@@ -144,4 +148,5 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/versionSeparator" />
     </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </LinearLayout>


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #21, and I have fixed the blocked texts on the about page by making it scrollable. I would appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/130622997-d8ce886c-c0fe-497d-bad4-627b0be0afcb.png" alt="copy" width="250"/>

Thanks again! Have a nice day! :)